### PR TITLE
Fix bad fmt log args, make L2 tracker/ethyl provider thread-safe

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1569,7 +1569,7 @@ bool Blockchain::validate_miner_transaction(
         if (b.reward != pool_block_reward) {
             log::error(
                     logcat,
-                    "block reward to be batched is incorrect({}). Block reward is {}, should be {}",
+                    "block reward to be batched is incorrect. Block reward is {}, should be {}",
                     print_money(b.reward),
                     print_money(pool_block_reward));
             return false;

--- a/src/l2_tracker/l2_tracker.h
+++ b/src/l2_tracker/l2_tracker.h
@@ -56,12 +56,7 @@ public:
     L2Tracker(const cryptonote::network_type nettype, const std::shared_ptr<Provider>& client);
     ~L2Tracker();
 
-    void update_state_thread();
     void update_state();
-    void insert_in_order(State&& new_state);
-
-    void process_logs_for_state(State& state);
-
     bool check_state_in_history(uint64_t height, const crypto::hash& state_root);
     bool check_state_in_history(uint64_t height, const std::string& state_root);
 
@@ -81,8 +76,12 @@ public:
     uint64_t get_pool_block_reward(uint64_t timestamp, uint64_t ethereum_block_height);
 
 private:
-    static std::string get_rewards_contract_address(const cryptonote::network_type nettype);
-    static std::string get_pool_contract_address(const cryptonote::network_type nettype);
+    void insert_in_order(State&& new_state);
+    void process_logs_for_state(State& state);
+
+    std::mutex mutex;
+    static std::string_view get_rewards_contract_address(const cryptonote::network_type nettype);
+    static std::string_view get_pool_contract_address(const cryptonote::network_type nettype);
     void get_review_transactions();
     void populate_review_transactions(std::shared_ptr<TransactionReviewSession> session);
     bool service_node = true;

--- a/src/l2_tracker/pool_contract.cpp
+++ b/src/l2_tracker/pool_contract.cpp
@@ -4,8 +4,8 @@
 
 static auto logcat = oxen::log::Cat("l2_tracker");
 
-PoolContract::PoolContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider)
-        : contractAddress(_contractAddress), provider(std::move(_provider)) {}
+PoolContract::PoolContract(std::string _contractAddress, std::shared_ptr<Provider> _provider)
+        : contractAddress(std::move(_contractAddress)), provider(std::move(_provider)) {}
 
 RewardRateResponse PoolContract::RewardRate(uint64_t timestamp, uint64_t ethereum_block_height) {
     ReadCallData callData;

--- a/src/l2_tracker/pool_contract.h
+++ b/src/l2_tracker/pool_contract.h
@@ -15,7 +15,7 @@ public:
 
 class PoolContract {
 public:
-    PoolContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);
+    PoolContract(std::string _contractAddress, std::shared_ptr<Provider> _provider);
     RewardRateResponse RewardRate(uint64_t timestamp, uint64_t ethereum_block_height);
 
 private:

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -1124,6 +1124,18 @@ bool oxen_chain_generator::block_begin(oxen_blockchain_entry &entry, oxen_create
     }
   }
 
+  // TODO(doyle): Pre-cursor work I started on to test some BLS features. However this is incorrect,
+  // the block reward has to be derived from the reward pool contract. This howver requires
+  // connecting L2 tracker to a Ethereum blockchain (like `hardhat node`). This makes running tests
+  // a lot more cumbersome. We should either mock the contract into the L2 tracker or startup a
+  // suitable testing environment for the core tests.
+  //
+  // Core tests are more like unit-tests however, so I'd lean more towards implementing a mock
+  // contract.
+  if (blk.major_version >= cryptonote::feature::ETH_BLS) {
+      block_rewards = 0;
+  }
+
   blk.reward = block_rewards;
   entry.txs = tx_list;
   uint64_t block_reward, block_reward_unpenalized;


### PR DESCRIPTION
Relies on https://github.com/oxen-io/ethyl/pull/20